### PR TITLE
🔧 Fix Docker startup script path - copy from build stage

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -55,8 +55,8 @@ COPY --from=deps /app/node_modules ./node_modules
 # Copy built application
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/package*.json ./
-# Copy startup script
-COPY startup.sh ./
+# Copy startup script from build stage
+COPY --from=build /app/startup.sh ./
 RUN chmod +x startup.sh
 # Create logs directory
 RUN mkdir -p /app/logs && chown -R serveruser:nodejs /app/logs


### PR DESCRIPTION
## Problem
Container was failing to start because `startup.sh` script couldn't be found. The error in logs showed:
```
[dumb-init] ./startup.sh: No such file or directory
```

## Root Cause
The Dockerfile was trying to copy `startup.sh` from the current build context instead of from the build stage where it was actually available.

## Solution
- Fixed the COPY instruction to use `--from=build` flag
- Changed from `COPY startup.sh ./` to `COPY --from=build /app/startup.sh ./`

## Testing
This should resolve the container startup failures and allow the Node.js application to start properly, fixing the health check failures at `http://56.228.14.41/api/health`.